### PR TITLE
clang complains on osx

### DIFF
--- a/gmodel.cpp
+++ b/gmodel.cpp
@@ -447,7 +447,7 @@ Extruded extrude_edge3(ObjPtr start, Transform tr, Extruded left, Extruded right
   auto loop = new_loop();
   add_use(loop, FORWARD, start);
   add_use(loop, FORWARD, right.middle);
-  ObjPtr end = 0;
+  ObjPtr end = nullptr;
   switch (start->type) {
     case LINE: {
       end = new_line2(std::dynamic_pointer_cast<Point>(left.end),
@@ -487,7 +487,7 @@ Extruded extrude_edge3(ObjPtr start, Transform tr, Extruded left, Extruded right
       break;
     }
     default:
-      end = 0;
+      end = nullptr;
       break;
   }
   add_use(loop, REVERSE, end);
@@ -503,7 +503,7 @@ Extruded extrude_edge3(ObjPtr start, Transform tr, Extruded left, Extruded right
       middle = new_ruled2(loop);
       break;
     default:
-      middle = 0;
+      middle = nullptr;
       break;
   }
   return Extruded{middle, end};


### PR DESCRIPTION
This PR silences some warnings from clang on my macbook running High Sierra (`10.13.4 (17E202)`).

```
clang --version
Apple LLVM version 9.1.0 (clang-902.0.39.1)
Target: x86_64-apple-darwin17.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```